### PR TITLE
Added parenthesis at the suggestion of PlatformIO compiler

### DIFF
--- a/src/CommandParser.h
+++ b/src/CommandParser.h
@@ -32,7 +32,7 @@ template<typename T> size_t strToInt(const char* buf, T *value, T min_value, T m
 
     // parse sign if necessary
     bool isNegative = false;
-    if (min_value < 0 && buf[position] == '+' || buf[position] == '-') {
+    if ((min_value < 0 && buf[position] == '+') || buf[position] == '-') {
         isNegative = buf[position] == '-';
         position ++;
     }


### PR DESCRIPTION
Hi
Great library! The PlarformIO compiler thinks that there should be parenthesis to accentuate that the && take precedence over the || which I think is a valid point. So I added them.